### PR TITLE
cleans up all compiler diagnostics

### DIFF
--- a/src/cellar.rs
+++ b/src/cellar.rs
@@ -66,7 +66,7 @@ async fn vacant(path: &PathBuf) -> Result<bool, Box<dyn std::error::Error>> {
 
     // Iterate over directory contents
     let mut entries = fs::read_dir(path).await?;
-    while let Some(_) = entries.next_entry().await? {
+    if entries.next_entry().await?.is_some() {
         return Ok(false); // Found at least one file/directory
     }
 
@@ -121,7 +121,7 @@ pub async fn resolve(pkg: &PackageReq, config: &Config) -> Result<Installation, 
 
 pub async fn has(pkg: &PackageReq, config: &Config) -> Option<Installation> {
     match resolve(pkg, config).await {
-        Ok(foo) => Some(foo),
+        Ok(inst) => Some(inst),
         Err(_) => None, //FIXME only swallow errors for the correct error types
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,7 @@ fn get_dist_url() -> String {
     if let Ok(env_url) = env::var("PKGX_DIST_URL") {
         return env_url;
     }
-    return "https://dist.pkgx.dev".to_string();
+    "https://dist.pkgx.dev".to_string()
 }
 
 fn get_pantry_dir() -> io::Result<PathBuf> {
@@ -38,7 +38,7 @@ fn get_pantry_dir() -> io::Result<PathBuf> {
             return Ok(path);
         }
     }
-    return Ok(dirs_next::cache_dir().unwrap().join("pkgx/pantry"));
+    Ok(dirs_next::cache_dir().unwrap().join("pkgx/pantry"))
 }
 
 fn get_pkgx_dir() -> io::Result<PathBuf> {

--- a/src/env.rs
+++ b/src/env.rs
@@ -8,6 +8,7 @@ pub fn map(installations: Vec<Installation>) -> HashMap<String, Vec<String>> {
 
     let projects: HashSet<_> = installations.iter().map(|i| &i.pkg.project).collect();
 
+    #[allow(clippy::unnecessary_to_owned)]
     let has_cmake = projects.contains(&"cmake.org".to_string());
     let archaic = true;
 
@@ -36,11 +37,7 @@ pub fn map(installations: Vec<Installation>) -> HashMap<String, Vec<String>> {
         ] {
             if let Some(suffixes) = suffixes(key) {
                 for suffix in suffixes {
-                    let path = installation
-                        .path
-                        .join(&suffix)
-                        .to_string_lossy()
-                        .to_string();
+                    let path = installation.path.join(suffix).to_string_lossy().to_string();
                     if !path.is_empty() {
                         vars.entry(key.as_ref().to_string())
                             .or_insert_with(OrderedSet::new)
@@ -73,7 +70,7 @@ pub fn map(installations: Vec<Installation>) -> HashMap<String, Vec<String>> {
         }
     }
 
-    if let Some(library_path) = vars.get(&EnvKey::LibraryPath.as_ref().to_string()) {
+    if let Some(library_path) = vars.get(EnvKey::LibraryPath.as_ref()) {
         let paths = library_path.to_vec();
         vars.entry(EnvKey::LdLibraryPath.as_ref().to_string())
             .or_insert_with(OrderedSet::new)
@@ -102,16 +99,20 @@ use strum_macros::{AsRefStr, EnumString};
 #[derive(Debug, EnumString, AsRefStr, PartialEq, Eq, Hash, Clone)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")] // Optional: enforce case style
 enum EnvKey {
+    #[allow(clippy::upper_case_acronyms)]
     PATH,
+    #[allow(clippy::upper_case_acronyms)]
     MANPATH,
     PkgConfigPath,
     LibraryPath,
     LdLibraryPath,
+    #[allow(clippy::upper_case_acronyms)]
     CPATH,
     XdgDataDirs,
     CmakePrefixPath,
     DyldFallbackLibraryPath,
     SslCertFile,
+    #[allow(clippy::upper_case_acronyms)]
     LDFLAGS,
     PkgxDir,
     AclocalPath,
@@ -172,5 +173,5 @@ pub fn mix(input: HashMap<String, Vec<String>>) -> HashMap<String, String> {
         rv.insert(key, values.join(":"));
     }
 
-    return rv;
+    rv
 }

--- a/src/help.rs
+++ b/src/help.rs
@@ -71,7 +71,7 @@ environmental influencers:
 
         let re = Regex::new("(?m)#.*$").unwrap();
 
-        re.replace_all(&usage, |caps: &regex::Captures| {
+        re.replace_all(usage, |caps: &regex::Captures| {
             dim(caps.get(0).unwrap().as_str())
         })
         .to_string()

--- a/src/install_multi.rs
+++ b/src/install_multi.rs
@@ -31,7 +31,7 @@ pub async fn install_multi(
     let mut promises = Vec::new();
     for pkg in pending {
         let shared_state = Arc::clone(&shared_state);
-        let promise = install::install(&pkg, &config, move |event| match event {
+        let promise = install::install(pkg, config, move |event| match event {
             install::InstallEvent::DownloadSize(size) => {
                 let mut state = shared_state.lock().unwrap();
                 state.total_size += size;

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -25,13 +25,13 @@ impl Error for DownloadError {}
 
 // Select function to pick a version
 pub async fn select(rq: &PackageReq, config: &Config) -> Result<Option<Version>, Box<dyn Error>> {
-    let versions = ls(&rq, config).await?;
+    let versions = ls(rq, config).await?;
 
-    return Ok(versions
+    Ok(versions
         .iter()
         .filter(|v| rq.constraint.satisfies(v))
         .max()
-        .cloned());
+        .cloned())
 }
 
 // Get function to fetch available versions
@@ -56,7 +56,7 @@ pub async fn ls(rq: &PackageReq, config: &Config) -> Result<Vec<Version>, Box<dy
     let releases = rsp.text().await?;
     let mut versions: Vec<Version> = releases
         .lines()
-        .map(|line| Version::parse(line))
+        .map(Version::parse)
         .filter_map(Result::ok)
         .collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         sync::replace(&config).await?;
         pantry_db::cache(&config)?
     } else {
-        rusqlite::Connection::open(&config.pantry_dir.parent().unwrap().join("pantry.db"))?
+        rusqlite::Connection::open(config.pantry_dir.parent().unwrap().join("pantry.db"))?
     };
 
     if !args.is_empty() && !args[0].contains('/') {

--- a/src/pantry.rs
+++ b/src/pantry.rs
@@ -35,7 +35,7 @@ impl PantryEntry {
                 .iter()
                 .map(|(k, v)| {
                     // if v is a number, prefix with ^
-                    let v = if v.chars().next().unwrap().is_digit(10) {
+                    let v = if v.chars().next().unwrap().is_ascii_digit() {
                         format!("^{}", v)
                     } else {
                         v.clone()

--- a/src/pantry_db.rs
+++ b/src/pantry_db.rs
@@ -49,7 +49,7 @@ pub fn cache(config: &Config) -> Result<Connection, Box<dyn std::error::Error>> 
 
     let tx = conn.transaction()?;
 
-    for pkg in pantry::ls(&config) {
+    for pkg in pantry::ls(config) {
         for program in pkg.programs {
             tx.execute(
                 "INSERT INTO provides (project, program) VALUES (?1, ?2);",
@@ -116,7 +116,7 @@ pub fn convert(
 
     for arg in args {
         let mut pkg = PackageReq::parse(arg)?;
-        if let Ok(project) = which(&pkg.project, &conn) {
+        if let Ok(project) = which(&pkg.project, conn) {
             pkg.project = project;
             pkgs.push(pkg);
         } else {

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -27,12 +27,12 @@ pub async fn resolve(reqs: Vec<PackageReq>, config: &Config) -> Result<Resolutio
     for req in reqs {
         let config_clone = config; // Clone config for use in async block
         futures.push(async move {
-            if let Some(installation) = cellar::has(&req, &config_clone).await {
+            if let Some(installation) = cellar::has(&req, config_clone).await {
                 Ok::<_, Box<dyn Error>>((
                     Some((installation.clone(), installation.pkg.clone())),
                     None,
                 ))
-            } else if let Ok(Some(version)) = inventory::select(&req, &config_clone).await {
+            } else if let Ok(Some(version)) = inventory::select(&req, config_clone).await {
                 let pkg = Package {
                     project: req.project.clone(),
                     version,

--- a/src/types.rs
+++ b/src/types.rs
@@ -172,7 +172,7 @@ pub fn host() -> (Host, Arch) {
         "x86_64" => Arch::X86_64,
         _ => panic!("Unsupported architecture"),
     };
-    return (host, arch);
+    (host, arch)
 }
 
 impl fmt::Display for Host {


### PR DESCRIPTION
@mxcl the only one that was a little sus was cellar.rs#L69. I _think_ that was what was intended, but the original loop wasn't ever going to run, per the compiler.
