### PR TITLE
move Regex::new() out of hot path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,6 +958,7 @@ dependencies = [
  "dirs-next",
  "futures",
  "indicatif",
+ "lazy_static",
  "libc",
  "libsemverator",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ tokio-tar = "0.3.1"
 tokio-util = { version = "0.7.13", features = ["compat"] }
 futures = "0.3.31"
 indicatif = "0.17.9"
+lazy_static = "1.5.0"

--- a/src/help.rs
+++ b/src/help.rs
@@ -69,6 +69,8 @@ environmental influencers:
   CLICOLOR   # see https://bixense.com/clicolors
 "#;
 
+        // not bothering to wrap this in a lazy_static! block
+        // because it's only used once
         let re = Regex::new("(?m)#.*$").unwrap();
 
         re.replace_all(&usage, |caps: &regex::Captures| {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,11 @@
+use lazy_static::lazy_static;
 use libsemverator::range::{Constraint, Range as VersionReq};
 use libsemverator::semver::Semver as Version;
 use std::fmt;
+
+lazy_static! {
+    static ref PACKAGE_REGEX: Regex = Regex::new(r"^(.+?)([\^=~<>@].+)?$").unwrap();
+}
 
 #[derive(Debug, Clone)]
 pub struct Package {
@@ -30,8 +35,7 @@ use regex::Regex;
 impl PackageReq {
     pub fn parse(pkgspec: String) -> Result<Self, Box<dyn std::error::Error>> {
         let input = pkgspec.trim();
-        let re = Regex::new(r"^(.+?)([\^=~<>@].+)?$")?;
-        let captures = re
+        let captures = PACKAGE_REGEX
             .captures(input)
             .ok_or_else(|| format!("invalid pkgspec: {}", input))?;
 


### PR DESCRIPTION
`Regex::new()` is potentially costly. Better to run it once and be done.