### PR TITLE
adds my standard rust-lang workflows

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -17,7 +17,10 @@ name: Check and Lint
 jobs:
   check:
     name: Check
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -49,7 +52,10 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -17,7 +17,7 @@ name: Check and Lint
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -49,7 +49,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -1,0 +1,75 @@
+# https://github.com/BamPeers/rust-ci-github-actions-workflow
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.rs"
+      - "**/*.toml"
+      - "**/*.lock"
+      # if we ever want to markdownlint
+      # - "**/*.md"
+
+name: Check and Lint
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+        env:
+          RUSTFLAGS: "-D warnings"
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: clippy
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-features
+        env:
+          RUSTFLAGS: "-D warnings"
+
+  # @mxcl hates this one, because he likes violating its rules without
+  # consequence or annotation.
+  # markdownlint:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: nosborn/github-action-markdown-cli@v3.2.0
+  #       with:
+  #         files: .

--- a/.github/workflows/release-packaging.yaml.todo
+++ b/.github/workflows/release-packaging.yaml.todo
@@ -1,0 +1,44 @@
+# https://github.com/BamPeers/rust-ci-github-actions-workflow
+
+# TODO:
+# on:
+#   release:
+#     types: [published]
+
+# name: Release Packaging
+
+# jobs:
+#   release:
+#     name: Release Packaging
+#     env:
+#       PROJECT_NAME_UNDERSCORE: pkgx
+#       RUSTFLAGS: "-D warnings"
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - uses: actions-rs/toolchain@v1
+#         with:
+#           profile: minimal
+#           toolchain: nightly
+#           override: true
+#       - name: Release Build
+#         run: cargo build --release
+#       - name: "Upload Artifact"
+#         uses: actions/upload-artifact@v4
+#         with:
+#           name: ${{ env.PROJECT_NAME_UNDERSCORE }}
+#           path: target/release/${{ env.PROJECT_NAME_UNDERSCORE }}
+
+#   publish:
+#     name: Publish to crates.io
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - uses: actions-rs/toolchain@v1
+#         with:
+#           profile: minimal
+#           toolchain: nightly
+#           override: true
+#       - uses: katyo/publish-crates@v2
+#         with:
+#           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/test.yml.todo
+++ b/.github/workflows/test.yml.todo
@@ -1,0 +1,65 @@
+# https://github.com/BamPeers/rust-ci-github-actions-workflow
+
+# TODO:
+# on:
+#   pull_request:
+#   push:
+#     branches:
+#       - main
+
+# name: Test with Code Coverage
+
+# permissions:
+#   contents: read
+#   checks: write
+#   pull-requests: write
+
+# jobs:
+#   test:
+#     name: Test
+#     env:
+#       PROJECT_NAME_UNDERSCORE: semverator
+#       CARGO_INCREMENTAL: 0
+#       RUSTFLAGS: -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort -D warnings
+#       RUSTDOCFLAGS: -Cpanic=abort
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - uses: actions-rs/toolchain@v1
+#         with:
+#           profile: minimal
+#           toolchain: nightly
+#           override: true
+#       - name: Cache dependencies
+#         uses: actions/cache@v4
+#         env:
+#           cache-name: cache-dependencies
+#         with:
+#           path: |
+#             ~/.cargo/.crates.toml
+#             ~/.cargo/.crates2.json
+#             ~/.cargo/bin
+#             ~/.cargo/registry/index
+#             ~/.cargo/registry/cache
+#             target
+#           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
+#   coverage:
+#     name: Coverage
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - uses: actions-rs/toolchain@v1
+#         with:
+#           profile: minimal
+#           toolchain: nightly
+#           override: true
+#       - name: Setup just
+#         uses: extractions/setup-just@v1
+#         env:
+#           GITHUB_TOKEN: ${{ github.token }}
+#       - name: Generate test result and coverage report
+#         run: |
+#           cargo install cargo-tarpaulin
+#           just coverage
+#         env:
+#           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}

--- a/.github/workflows/test.yml.todo
+++ b/.github/workflows/test.yml.todo
@@ -22,7 +22,10 @@
 #       CARGO_INCREMENTAL: 0
 #       RUSTFLAGS: -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort -D warnings
 #       RUSTDOCFLAGS: -Cpanic=abort
-#     runs-on: ubuntu-latest
+#     strategy:
+#       matrix:
+#         os: [ubuntu-latest, macos-latest]
+#     runs-on: ${{ matrix.os }}
 #     steps:
 #       - uses: actions/checkout@v4
 #       - uses: actions-rs/toolchain@v1
@@ -45,7 +48,10 @@
 #           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
 #   coverage:
 #     name: Coverage
-#     runs-on: ubuntu-latest
+#     strategy:
+#       matrix:
+#         os: [ubuntu-latest, macos-latest]
+#     runs-on: ${{ matrix.os }}
 #     steps:
 #       - uses: actions/checkout@v4
 #       - uses: actions-rs/toolchain@v1
@@ -53,13 +59,9 @@
 #           profile: minimal
 #           toolchain: nightly
 #           override: true
-#       - name: Setup just
-#         uses: extractions/setup-just@v1
-#         env:
-#           GITHUB_TOKEN: ${{ github.token }}
 #       - name: Generate test result and coverage report
 #         run: |
 #           cargo install cargo-tarpaulin
-#           just coverage
+#           cargo tarpaulin --engine ptrace -o lcov --output-dir coverage --coveralls $COVERALLS_TOKEN
 #         env:
 #           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,9 +1,9 @@
 use crate::config::Config;
 use async_compression::tokio::bufread::GzipDecoder;
 use futures::TryStreamExt;
-use tokio_util::compat::FuturesAsyncReadCompatExt;
 use std::path::PathBuf;
 use tokio_tar::Archive;
+use tokio_util::compat::FuturesAsyncReadCompatExt;
 
 pub fn should(config: &Config) -> bool {
     !config.pantry_dir.join("projects").exists()


### PR DESCRIPTION
includes two inactive, future-looking workflows:
- release to crates.io
- test/coverage

~~most importantly, fixes the linux build here: [src/execve.rs](https://github.com/pkgxdev/pkgx.rs/pull/3/files#diff-598a346ae9d6ad94647ce60a9037a5e84540722070b1853921e30a234b3377ca)~~

~~possibly the `nix` crate, sitting over the `libc` crate is the usual way to work around this. didn't test for overhead. attempt using nix is #4.~~ handled in #4