### PR TITLE
use `nix` for standardized+safe libc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "console"
 version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +844,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,8 +977,8 @@ dependencies = [
  "futures",
  "indicatif",
  "lazy_static",
- "libc",
  "libsemverator",
+ "nix",
  "regex",
  "reqwest",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ tokio = { version = "1.0", features = ["full", "rt-multi-thread"] }
 tokio-stream = "0.1"
 strum = "0.24"
 strum_macros = "0.24"
-libc = "0.2.169"
 rusqlite = "0.32.1"
 regex = "1.11.1"
 reqwest = { version = "0.11", features = ["stream", "blocking"] }
@@ -25,3 +24,4 @@ tokio-util = { version = "0.7.13", features = ["compat"] }
 futures = "0.3.31"
 indicatif = "0.17.9"
 lazy_static = "1.5.0"
+nix = { version = "0.29.0", features = ["process"] }


### PR DESCRIPTION
see [here](https://github.com/pkgxdev/pkgx.rs/actions/runs/12588857682/job/35087587942) for rationale.