### PR TITLE
move `indicatif` to only live in `cli`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,6 @@ dependencies = [
  "dirs-next",
  "fs2",
  "futures",
- "indicatif",
  "lazy_static",
  "libsemverator",
  "nix",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -24,7 +24,6 @@ async-compression = { version = "0.4", features = ["tokio", "gzip", "xz"] }
 tokio-tar = "0.3.1"
 tokio-util = { version = "0.7.13", features = ["compat"] }
 futures = "0.3.31"
-indicatif = "0.17.9"
 lazy_static = "1.5.0"
 nix = { version = "0.29.0", features = ["process"] }
 fs2 = "0.4.3"

--- a/lib/src/install_multi.rs
+++ b/lib/src/install_multi.rs
@@ -1,26 +1,23 @@
 use std::error::Error;
-use std::fmt::Write;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::sync::Arc;
 
 use crate::install::{install, InstallEvent};
 use crate::types::{Installation, Package};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 
 use crate::config::Config;
+
+pub trait ProgressBarExt {
+    fn inc(&self, n: u64);
+    fn inc_length(&self, n: u64);
+}
 
 pub async fn install_multi(
     pending: &[Package],
     config: &Config,
-    pb: Option<ProgressBar>,
+    pb: Option<Arc<impl ProgressBarExt + Send + Sync + 'static>>,
 ) -> Result<Vec<Installation>, Box<dyn Error>> {
-    let pb = pb.map(|pb| {
-        configure_bar(&pb);
-        Arc::new(Mutex::new(pb))
-    });
-
     pending
         .iter()
         .map(|pkg| {
@@ -30,10 +27,10 @@ pub async fn install_multi(
                 pb.clone().map(|pb| {
                     move |event| match event {
                         InstallEvent::DownloadSize(size) => {
-                            pb.lock().unwrap().inc_length(size);
+                            pb.inc_length(size);
                         }
                         InstallEvent::Progress(chunk) => {
-                            pb.lock().unwrap().inc(chunk);
+                            pb.inc(chunk);
                         }
                     }
                 }),
@@ -44,66 +41,4 @@ pub async fn install_multi(
         .await
         .into_iter()
         .collect()
-}
-
-fn configure_bar(pb: &ProgressBar) {
-    pb.set_length(1);
-    pb.set_style(
-        ProgressStyle::with_template(
-            "{elapsed:.dim} ❲{wide_bar:.red}❳ {percent}% {bytes_per_sec:.dim} {bytes:.dim}",
-        )
-        .unwrap()
-        .with_key("elapsed", |state: &ProgressState, w: &mut dyn Write| {
-            let s = state.elapsed().as_secs_f64();
-            let precision = precision(s);
-            write!(w, "{:.precision$}s", s, precision = precision).unwrap()
-        })
-        .with_key("bytes", |state: &ProgressState, w: &mut dyn Write| {
-            let (right, divisor) = pretty_size(state.len().unwrap());
-            let left = state.pos() as f64 / divisor as f64;
-            let leftprecision = precision(left);
-            write!(
-                w,
-                "{:.precision$}/{}",
-                left,
-                right,
-                precision = leftprecision
-            )
-            .unwrap()
-        })
-        .progress_chars("⚯ "),
-    );
-    pb.enable_steady_tick(Duration::from_millis(50));
-}
-
-fn pretty_size(n: u64) -> (String, u64) {
-    let units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
-    let mut size = n as f64;
-    let mut i = 0;
-    let mut divisor = 1;
-
-    while size > 1024.0 && i < units.len() - 1 {
-        size /= 1024.0;
-        i += 1;
-        divisor *= 1024;
-    }
-
-    let formatted = format!(
-        "{:.precision$} {}",
-        size,
-        units[i],
-        precision = precision(size)
-    );
-
-    (formatted, divisor)
-}
-
-fn precision(n: f64) -> usize {
-    if n < 10.0 {
-        2
-    } else if n < 100.0 {
-        1
-    } else {
-        0
-    }
 }


### PR DESCRIPTION
wrapping types for the win. feels dirty, but i pass a trait out and a wrapper type back in.